### PR TITLE
feat(config): 添加配方移除配置功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ public static final TagKey<Block> INCORRECT_FOR_CUSTOM_TOOL =
 
 * **神恩✘晓月**
 * **ฅ呜喵ฅ**
-* **Prizowo**
+* **LirxOwO**
 * **啊哈**
 * **小胡闹**
 * **安宁**

--- a/run/config/elake_tech/recipe_removal.json
+++ b/run/config/elake_tech/recipe_removal.json
@@ -1,0 +1,11 @@
+{
+  "modsToRemove": [
+    "example_mod"
+  ],
+  "recipesToRemove": [
+    "minecraft:furnace",
+    "minecraft:diamond_block"
+  ],
+  "modIds": [],
+  "recipeIds": []
+}

--- a/src/main/java/top/elake/elaketech/ElakeTech.java
+++ b/src/main/java/top/elake/elaketech/ElakeTech.java
@@ -27,7 +27,7 @@ import top.elake.elaketech.server.recipes.remove.*;
  */
 @Mod(ElakeTech.MODID)
 public class ElakeTech {
-    public static final String MODID = "elaketech";
+    public static final String MODID = "elake_tech";
 
     public static final Registrate REGISTER = Registrate.create(MODID);
 

--- a/src/main/java/top/elake/elaketech/ElakeTech.java
+++ b/src/main/java/top/elake/elaketech/ElakeTech.java
@@ -4,9 +4,13 @@ import com.tterrag.registrate.Registrate;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.capabilities.*;
 import net.neoforged.neoforge.common.NeoForge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import top.elake.elaketech.client.ModTooltip;
+import top.elake.elaketech.config.RecipeRemovalConfig;
 import top.elake.elaketech.datagen.assets.model.*;
 import top.elake.elaketech.datagen.assets.translation.Common;
 import top.elake.elaketech.event.*;
@@ -23,7 +27,7 @@ import top.elake.elaketech.server.recipes.remove.*;
  */
 @Mod(ElakeTech.MODID)
 public class ElakeTech {
-    public static final String MODID = "elake_tech";
+    public static final String MODID = "elaketech";
 
     public static final Registrate REGISTER = Registrate.create(MODID);
 
@@ -31,13 +35,19 @@ public class ElakeTech {
         return ResourceLocation.fromNamespaceAndPath(MODID, String.valueOf(path));
     }
 
-
     /**
      * 构造函数
      *
      * @param event 事件总线
      */
     public ElakeTech(IEventBus event) {
+
+        // 确保配置目录存在
+        FMLPaths.CONFIGDIR.get().resolve(MODID).toFile().mkdirs();
+        
+        // 预加载配置
+        RecipeRemovalConfig.getInstance();
+
         // 元素
         Element.ElementGroup.register();
         // 创造模式物品栏

--- a/src/main/java/top/elake/elaketech/config/RecipeRemovalConfig.java
+++ b/src/main/java/top/elake/elaketech/config/RecipeRemovalConfig.java
@@ -1,0 +1,133 @@
+package top.elake.elaketech.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.loading.FMLPaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import top.elake.elaketech.ElakeTech;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RecipeRemovalConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecipeRemovalConfig.class);
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String CONFIG_FILE = "recipe_removal.json";
+    
+    private List<String> modsToRemove = new ArrayList<>();
+    private List<String> recipesToRemove = new ArrayList<>();
+    
+    private static RecipeRemovalConfig INSTANCE;
+    
+    // 配方移除数据，使用transient防止序列化
+    private final transient Set<String> modIds = new HashSet<>();
+    private final transient Set<ResourceLocation> recipeIds = new HashSet<>();
+    
+    private RecipeRemovalConfig() {
+        // 私有构造函数
+    }
+    
+    public static RecipeRemovalConfig getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new RecipeRemovalConfig();
+            INSTANCE.loadConfig();
+        }
+        return INSTANCE;
+    }
+    
+    public Set<String> getModIds() {
+        return modIds;
+    }
+    
+    public Set<ResourceLocation> getRecipeIds() {
+        return recipeIds;
+    }
+    
+    public void loadConfig() {
+        Path configDir = FMLPaths.CONFIGDIR.get().resolve(ElakeTech.MODID);
+        File configFile = configDir.resolve(CONFIG_FILE).toFile();
+        
+        // 确保配置目录存在
+        if (!configDir.toFile().exists()) {
+            try {
+                Files.createDirectories(configDir);
+            } catch (IOException e) {
+                LOGGER.error("Failed to create config directory", e);
+                return;
+            }
+        }
+        
+        // 如果配置文件不存在，创建默认配置
+        if (!configFile.exists()) {
+            createDefaultConfig(configFile);
+        }
+        
+        // 读取配置
+        try (FileReader reader = new FileReader(configFile)) {
+            Type type = new TypeToken<RecipeRemovalConfig>() {}.getType();
+            RecipeRemovalConfig config = GSON.fromJson(reader, type);
+            
+            // 更新实例数据
+            if (config != null) {
+                this.modsToRemove = config.modsToRemove;
+                this.recipesToRemove = config.recipesToRemove;
+                
+                // 解析数据
+                parseConfig();
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error loading recipe removal config", e);
+            // 配置加载失败时，使用默认空配置
+            this.modsToRemove = new ArrayList<>();
+            this.recipesToRemove = new ArrayList<>();
+        }
+    }
+    
+    private void parseConfig() {
+        // 清除旧数据
+        modIds.clear();
+        recipeIds.clear();
+        
+        // 添加模组ID
+        modIds.addAll(modsToRemove);
+        
+        // 解析配方ID
+        for (String recipeString : recipesToRemove) {
+            try {
+                recipeIds.add(ResourceLocation.parse(recipeString));
+            } catch (Exception e) {
+                LOGGER.warn("Invalid recipe ID in config: {}", recipeString);
+            }
+        }
+    }
+    
+    private void createDefaultConfig(File configFile) {
+        // 默认配置示例
+        RecipeRemovalConfig defaultConfig = new RecipeRemovalConfig();
+        defaultConfig.modsToRemove = new ArrayList<>();
+        defaultConfig.recipesToRemove = new ArrayList<>();
+        
+        // 添加一些示例 （可以删除）
+//        defaultConfig.modsToRemove.add("example_mod");
+//        defaultConfig.recipesToRemove.add("minecraft:furnace");
+//        defaultConfig.recipesToRemove.add("minecraft:diamond_block");
+        
+        try (FileWriter writer = new FileWriter(configFile)) {
+            GSON.toJson(defaultConfig, writer);
+        } catch (IOException e) {
+            LOGGER.error("Failed to create default config file", e);
+        }
+    }
+} 

--- a/src/main/java/top/elake/elaketech/config/RecipeRemovalConfig.java
+++ b/src/main/java/top/elake/elaketech/config/RecipeRemovalConfig.java
@@ -124,7 +124,6 @@ public class RecipeRemovalConfig {
         
         try (FileWriter writer = new FileWriter(configFile)) {
             GSON.toJson(defaultConfig, writer);
-            LOGGER.info("Created default recipe removal config file");
         } catch (IOException e) {
             LOGGER.error("Failed to create default config file", e);
         }

--- a/src/main/java/top/elake/elaketech/config/RecipeRemovalConfig.java
+++ b/src/main/java/top/elake/elaketech/config/RecipeRemovalConfig.java
@@ -31,9 +31,9 @@ public class RecipeRemovalConfig {
     
     private static RecipeRemovalConfig INSTANCE;
     
-    // 配方移除数据，使用transient防止序列化
-    private final transient Set<String> modIds = new HashSet<>();
-    private final transient Set<ResourceLocation> recipeIds = new HashSet<>();
+    // 配方移除数据
+    private final Set<String> modIds = new HashSet<>();
+    private final Set<ResourceLocation> recipeIds = new HashSet<>();
     
     private RecipeRemovalConfig() {
         // 私有构造函数
@@ -64,7 +64,6 @@ public class RecipeRemovalConfig {
             try {
                 Files.createDirectories(configDir);
             } catch (IOException e) {
-                LOGGER.error("Failed to create config directory", e);
                 return;
             }
         }
@@ -86,10 +85,9 @@ public class RecipeRemovalConfig {
                 
                 // 解析数据
                 parseConfig();
+                
             }
         } catch (Exception e) {
-            LOGGER.error("Error loading recipe removal config", e);
-            // 配置加载失败时，使用默认空配置
             this.modsToRemove = new ArrayList<>();
             this.recipesToRemove = new ArrayList<>();
         }
@@ -119,15 +117,16 @@ public class RecipeRemovalConfig {
         defaultConfig.modsToRemove = new ArrayList<>();
         defaultConfig.recipesToRemove = new ArrayList<>();
         
-        // 添加一些示例 （可以删除）
-//        defaultConfig.modsToRemove.add("example_mod");
-//        defaultConfig.recipesToRemove.add("minecraft:furnace");
-//        defaultConfig.recipesToRemove.add("minecraft:diamond_block");
+        // 添加一些示例
+        defaultConfig.modsToRemove.add("example_mod");
+        defaultConfig.recipesToRemove.add("minecraft:furnace");
+        defaultConfig.recipesToRemove.add("minecraft:diamond_block");
         
         try (FileWriter writer = new FileWriter(configFile)) {
             GSON.toJson(defaultConfig, writer);
+            LOGGER.info("Created default recipe removal config file");
         } catch (IOException e) {
             LOGGER.error("Failed to create default config file", e);
         }
     }
-} 
+}

--- a/src/main/java/top/elake/elaketech/event/RemoveRecipes.java
+++ b/src/main/java/top/elake/elaketech/event/RemoveRecipes.java
@@ -24,14 +24,12 @@ import java.util.stream.Collectors;
  */
 @EventBusSubscriber(modid = ElakeTech.MODID, bus = EventBusSubscriber.Bus.GAME, value = { Dist.CLIENT, Dist.DEDICATED_SERVER })
 public class RemoveRecipes {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveRecipes.class);
 
     /**
      * 在服务器启动前加载配置
      */
     @SubscribeEvent
     public static void onServerStarting(ServerStartingEvent event) {
-        LOGGER.info("Loading recipe removal configuration");
         RecipeRemovalConfig.getInstance().loadConfig();
     }
 
@@ -58,7 +56,6 @@ public class RemoveRecipes {
         
         // 如果配置为空，不需要进行处理
         if (modsToRemove.isEmpty() && recipesToRemove.isEmpty()) {
-            LOGGER.info("No recipes to remove from configuration");
             return;
         }
         
@@ -74,6 +71,5 @@ public class RemoveRecipes {
         recipeManager.replaceRecipes(recipesToKeep);
         
         int removedCount = originalSize - recipesToKeep.size();
-        LOGGER.info("Removed {} recipes based on configuration", removedCount);
     }
 }

--- a/src/main/java/top/elake/elaketech/event/RemoveRecipes.java
+++ b/src/main/java/top/elake/elaketech/event/RemoveRecipes.java
@@ -6,12 +6,17 @@ import net.minecraft.world.item.crafting.RecipeManager;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.client.event.RecipesUpdatedEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import top.elake.elaketech.ElakeTech;
+import top.elake.elaketech.config.RecipeRemovalConfig;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,58 +25,49 @@ import java.util.stream.Collectors;
  */
 @EventBusSubscriber(modid = ElakeTech.MODID, bus = EventBusSubscriber.Bus.GAME, value = { Dist.CLIENT, Dist.DEDICATED_SERVER })
 public class RemoveRecipes {
-    private static final Set<String> MODS_TO_REMOVE = new HashSet<>();
-    private static final Set<ResourceLocation> RECIPES_TO_REMOVE = new HashSet<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveRecipes.class);
 
     /**
-     * 删除模组的所有配方
-     * 例如: removeMod("mekanism");
+     * 在服务器启动前加载配置
      */
-    public static void removeMod(String modId) {
-        MODS_TO_REMOVE.add(modId);
+    @SubscribeEvent
+    public static void onServerStarting(ServerStartingEvent event) {
+        RecipeRemovalConfig.getInstance().loadConfig();
     }
 
     /**
-     * 删除物品ID的配方
-     * 例如: removeItemId("minecraft:diamond_block");
+     * 客户端配方更新时移除配方
      */
-    public static void removeItemId(String itemId) {
-        RECIPES_TO_REMOVE.add(ResourceLocation.parse(itemId));
-    }
-
-    /**
-     * 删除配方ID的配方
-     * 例如: removeRecipeId("mekanism:factory/advanced/purifying");
-     */
-    public static void removeRecipeId(String recipeId) {
-        RECIPES_TO_REMOVE.add(ResourceLocation.parse(recipeId));
-    }
-
-    /**
-     * 删除指定命名空间和路径的配方
-     * 例如: removeRecipe("minecraft", "furnace");
-     */
-    public static void removeRecipe(String namespace, String path) {
-        RECIPES_TO_REMOVE.add(ResourceLocation.fromNamespaceAndPath(namespace, path));
-    }
-
     @SubscribeEvent
     public static void onRecipesUpdated(RecipesUpdatedEvent event) {
         removeRecipes(event.getRecipeManager());
     }
 
+    /**
+     * 服务器启动时移除配方
+     */
     @SubscribeEvent
     public static void onServerStarted(ServerStartedEvent event) {
         removeRecipes(event.getServer().getRecipeManager());
     }
 
     private static void removeRecipes(RecipeManager recipeManager) {
+        RecipeRemovalConfig config = RecipeRemovalConfig.getInstance();
+        Set<String> modsToRemove = config.getModIds();
+        Set<ResourceLocation> recipesToRemove = config.getRecipeIds();
+        
+        // 如果配置为空，不需要进行处理
+        if (modsToRemove.isEmpty() && recipesToRemove.isEmpty()) {
+            return;
+        }
+        
         Collection<RecipeHolder<?>> allRecipes = recipeManager.getRecipes();
         Collection<RecipeHolder<?>> recipesToKeep = allRecipes.stream()
                 .filter((holder) -> {
                     ResourceLocation id = holder.id();
-                    return !MODS_TO_REMOVE.contains(id.getNamespace()) && !RECIPES_TO_REMOVE.contains(id);
+                    return !modsToRemove.contains(id.getNamespace()) && !recipesToRemove.contains(id);
                 }).collect(Collectors.toList());
+        
         recipeManager.replaceRecipes(recipesToKeep);
     }
 }

--- a/src/main/java/top/elake/elaketech/event/RemoveRecipes.java
+++ b/src/main/java/top/elake/elaketech/event/RemoveRecipes.java
@@ -7,7 +7,6 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.client.event.RecipesUpdatedEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
@@ -32,6 +31,7 @@ public class RemoveRecipes {
      */
     @SubscribeEvent
     public static void onServerStarting(ServerStartingEvent event) {
+        LOGGER.info("Loading recipe removal configuration");
         RecipeRemovalConfig.getInstance().loadConfig();
     }
 
@@ -58,10 +58,13 @@ public class RemoveRecipes {
         
         // 如果配置为空，不需要进行处理
         if (modsToRemove.isEmpty() && recipesToRemove.isEmpty()) {
+            LOGGER.info("No recipes to remove from configuration");
             return;
         }
         
         Collection<RecipeHolder<?>> allRecipes = recipeManager.getRecipes();
+        int originalSize = allRecipes.size();
+        
         Collection<RecipeHolder<?>> recipesToKeep = allRecipes.stream()
                 .filter((holder) -> {
                     ResourceLocation id = holder.id();
@@ -69,5 +72,8 @@ public class RemoveRecipes {
                 }).collect(Collectors.toList());
         
         recipeManager.replaceRecipes(recipesToKeep);
+        
+        int removedCount = originalSize - recipesToKeep.size();
+        LOGGER.info("Removed {} recipes based on configuration", removedCount);
     }
 }

--- a/src/main/java/top/elake/elaketech/server/recipes/remove/ItemRecipes.java
+++ b/src/main/java/top/elake/elaketech/server/recipes/remove/ItemRecipes.java
@@ -1,28 +1,64 @@
 package top.elake.elaketech.server.recipes.remove;
 
-import top.elake.elaketech.event.RemoveRecipes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import top.elake.elaketech.ElakeTech;
+import top.elake.elaketech.config.RecipeRemovalConfig;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import net.neoforged.fml.loading.FMLPaths;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * @author Qi-Month
  * @author Erhai-lake
  */
 public class ItemRecipes {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ItemRecipes.class);
+    
+    /**
+     * 该方法仅创建默认配置文件（如果不存在）
+     */
     public static void removeRecipes() {
-        List<String> itemGroup = List.of(
-                // 其它杂物
-                "minecraft:bucket",
-                // 工作方块
-                "minecraft:crafting_table",
-                "minecraft:furnace"
-        );
-        itemGroup.forEach(RemoveRecipes::removeItemId);
-        // 工具
-        List<String> toolGroup = List.of("_sword", "_pickaxe", "_axe", "_shovel", "_hoe");
-        toolGroup.forEach((toolType) -> {
-            RemoveRecipes.removeItemId("minecraft:wooden" + toolType);
-            RemoveRecipes.removeItemId("minecraft:stone" + toolType);
-        });
+        createRemovalConfigIfNotExists();
+    }
+    
+    /**
+     * 创建一个包含默认移除项的配置文件
+     */
+    private static void createRemovalConfigIfNotExists() {
+        Path configDir = FMLPaths.CONFIGDIR.get().resolve(ElakeTech.MODID);
+        File configFile = configDir.resolve("recipe_removal.json").toFile();
+        
+        if (!configFile.exists()) {
+            configDir.toFile().mkdirs();
+            
+            try {
+                // 创建自定义的配置对象
+                RecipeConfig config = new RecipeConfig();
+                
+                // 保存配置
+                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                try (FileWriter writer = new FileWriter(configFile)) {
+                    gson.toJson(config, writer);
+                }
+            } catch (IOException e) {
+                LOGGER.error("创建配方移除配置文件失败", e);
+            }
+        }
+    }
+    
+    /**
+     * 配方配置类
+     */
+    private static class RecipeConfig {
+        List<String> modsToRemove = new ArrayList<>();
+        List<String> recipesToRemove = new ArrayList<>();
     }
 }

--- a/src/main/java/top/elake/elaketech/server/recipes/remove/ItemRecipes.java
+++ b/src/main/java/top/elake/elaketech/server/recipes/remove/ItemRecipes.java
@@ -49,7 +49,7 @@ public class ItemRecipes {
                     gson.toJson(config, writer);
                 }
             } catch (IOException e) {
-                LOGGER.error("创建配方移除配置文件失败", e);
+                LOGGER.error("Failed to create recipe removal configuration file", e);
             }
         }
     }


### PR DESCRIPTION
- 新增 RecipeRemovalConfig 类用于管理配方移除配置
- 在 ElakeTech 类中添加配置目录创建和预加载配置的逻辑
- 修改 ItemRecipes 类，实现创建默认配置文件的功能- 更新 RemoveRecipes 类，支持从配置文件中读取并应用配方移除设置